### PR TITLE
Add pdfContentHeight prop

### DIFF
--- a/src/vue-html2pdf.vue
+++ b/src/vue-html2pdf.vue
@@ -9,7 +9,7 @@
 		>
 			<section
 				class="content-wrapper"
-				:style="`width: ${pdfContentWidth};`"
+				:style="`width: ${pdfContentWidth}; height: ${pdfContentHeight};`"
 				ref="pdfContent"
 			>
 				<slot name="pdf-content"/>
@@ -81,6 +81,10 @@ export default {
 
 		pdfContentWidth: {
 			default: '800px'
+		},
+		
+		pdfContentHeight: {
+			default: '1132px'
 		},
 
 		htmlToPdfOptions: {


### PR DESCRIPTION
Add pdfContentHeight as prop with 1132px as default to guard A4 proportions. A pdf in landscape gets messed up when a console tab is opened on the side, this way the user can specify the exact dimensions of the wrapper.